### PR TITLE
WIP: Update log4net minimum dependency

### DIFF
--- a/packaging/nuget/NServiceBus.Log4Net.nuspec
+++ b/packaging/nuget/NServiceBus.Log4Net.nuspec
@@ -16,7 +16,7 @@
     <tags>$tags$</tags>
     <dependencies>
       <dependency id="NServiceBus" version="[6.0.0-beta, 7.0.0)" />
-      <dependency id="Log4Net" version="[2.0.0, 3.0.0)" />
+      <dependency id="Log4Net" version="[2.0.5, 3.0.0)" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
As pointed out in https://github.com/Particular/NServiceBus.Host/issues/83, because we are building against log4net 2.0.5, we need our minimum dependency in the nuspec to also be 2.0.5. Without this, NuGet will try to install 2.0.0 by default. Because log4net changes assembly versions for each release, this doesn't work and NuGet cannot automatically create the correct binding redirects.